### PR TITLE
Fat JAR support for the engine

### DIFF
--- a/vtl-engine/pom.xml
+++ b/vtl-engine/pom.xml
@@ -49,5 +49,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
Modifying the Maven build package phase in order to produce a fat - or standalone - JAR. It is necessary for darkr (https://github.com/romaintailhurat/darkr)