### PR TITLE
Support unordered deserialization of dataset

### DIFF
--- a/vtl-jackson/src/main/java/fr/insee/vtl/jackson/DatasetDeserializer.java
+++ b/vtl-jackson/src/main/java/fr/insee/vtl/jackson/DatasetDeserializer.java
@@ -39,13 +39,12 @@ public class DatasetDeserializer extends StdDeserializer<Dataset> {
         List<List<Object>> dataPoints = null;
 
         while (p.nextToken() != JsonToken.END_OBJECT) {
-            String currentName = p.nextFieldName();
-            if (STRUCTURE_NAMES.contains(currentName)) {
+            if (STRUCTURE_NAMES.contains(p.currentName())) {
                 structure = deserializeStructure(p, ctxt);
                 if (dataPoints != null) {
                     convertDataPoints(p, dataPoints, structure);
                 }
-            } else if (DATAPOINT_NAMES.contains(currentName)) {
+            } else if (DATAPOINT_NAMES.contains(p.currentName())) {
                 if (structure != null) {
                     dataPoints = deserializeDataPoints(p, ctxt, structure);
                 } else {

--- a/vtl-jackson/src/test/java/fr/insee/vtl/jackson/DatasetDeserializerTest.java
+++ b/vtl-jackson/src/test/java/fr/insee/vtl/jackson/DatasetDeserializerTest.java
@@ -37,4 +37,31 @@ public class DatasetDeserializerTest extends AbstractMapperTest {
         );
 
     }
+
+    @Test
+    public void testDeserializeInvertedDataset() throws IOException {
+        var jsonStream = getClass().getResourceAsStream("/dataset-inverted.json");
+
+        var dataset = mapper.readValue(jsonStream, Dataset.class);
+
+        assertThat(dataset.getDataStructure().values()).containsExactly(
+                new Dataset.Component("CONTINENT", String.class, Dataset.Role.IDENTIFIER),
+                new Dataset.Component("COUNTRY", String.class, Dataset.Role.IDENTIFIER),
+                new Dataset.Component("POP", Long.class, Dataset.Role.MEASURE),
+                new Dataset.Component("AREA", Double.class, Dataset.Role.MEASURE)
+        );
+
+        List<Object> nulls = new ArrayList<>();
+        nulls.add(null);
+        nulls.add(null);
+        nulls.add(null);
+        nulls.add(null);
+        assertThat(dataset.getDataAsList()).containsExactly(
+                List.of("Europe", "France", 67063703L, 643.801),
+                List.of("Europe", "Norway", 5372191L, 385.203),
+                List.of("Oceania", "New Zealand", 4917000L, 268.021),
+                nulls
+        );
+
+    }
 }

--- a/vtl-jackson/src/test/resources/dataset-inverted.json
+++ b/vtl-jackson/src/test/resources/dataset-inverted.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    [
+      "Europe",
+      "France",
+      67063703,
+      643.801
+    ],
+    [
+      "Europe",
+      "Norway",
+      5372191,
+      385.203
+    ],
+    [
+      "Oceania",
+      "New Zealand",
+      4917000,
+      268.021
+    ],
+    [
+      null,
+      null,
+      null,
+      null
+    ]
+  ],
+  "structure": [
+    {
+      "name": "CONTINENT",
+      "type": "STRING",
+      "role": "IDENTIFIER"
+    },
+    {
+      "name": "COUNTRY",
+      "type": "STRING",
+      "role": "IDENTIFIER"
+    },
+    {
+      "name": "POP",
+      "type": "INTEGER",
+      "role": "MEASURE"
+    },
+    {
+      "name": "AREA",
+      "type": "NUMBER",
+      "role": "MEASURE"
+    }
+  ]
+}


### PR DESCRIPTION
When the data comes before the structure we need to buffer the data and convert when the structure is known. We use the ObjectCodec and TokenBuffer to handle conversion.

Fixes #38 