### PR TITLE
Spark optimizations

### DIFF
--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/processors/InMemoryProcessingEngine.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/processors/InMemoryProcessingEngine.java
@@ -18,7 +18,7 @@ public class InMemoryProcessingEngine implements ProcessingEngine {
 
     @Override
     public DatasetExpression executeCalc(DatasetExpression expression, Map<String, ResolvableExpression> expressions,
-                                         Map<String, Dataset.Role> roles) {
+                                         Map<String, Dataset.Role> roles, Map<String, String> expressionStrings) {
 
         // Copy the structure and mutate based on the expressions.
         var newStructure = new DataStructure(expression.getDataStructure());
@@ -52,7 +52,7 @@ public class InMemoryProcessingEngine implements ProcessingEngine {
     }
 
     @Override
-    public DatasetExpression executeFilter(DatasetExpression expression, ResolvableExpression filter) {
+    public DatasetExpression executeFilter(DatasetExpression expression, ResolvableExpression filter, String filterText) {
         return new DatasetExpression() {
 
             @Override

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/VtlScriptEngineTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/VtlScriptEngineTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class VtlScriptEngineTest {
 

--- a/vtl-model/src/main/java/fr/insee/vtl/model/ProcessingEngine.java
+++ b/vtl-model/src/main/java/fr/insee/vtl/model/ProcessingEngine.java
@@ -20,7 +20,7 @@ public interface ProcessingEngine {
      * @return the result of the calc transformation
      */
     DatasetExpression executeCalc(DatasetExpression expression, Map<String, ResolvableExpression> expressions,
-                                  Map<String, Dataset.Role> roles);
+                                  Map<String, Dataset.Role> roles, Map<String, String> expressionStrings);
 
     /**
      * Execute a filter transformations on the dataset expression.
@@ -31,7 +31,7 @@ public interface ProcessingEngine {
      * @param filter     a filter expression
      * @return the result of the filter transformation
      */
-    DatasetExpression executeFilter(DatasetExpression expression, ResolvableExpression filter);
+    DatasetExpression executeFilter(DatasetExpression expression, ResolvableExpression filter, String filterString);
 
     /**
      * Execute a rename transformations on the dataset expression.

--- a/vtl-spark/src/main/java/fr/insee/vtl/spark/SparkProcessingEngine.java
+++ b/vtl-spark/src/main/java/fr/insee/vtl/spark/SparkProcessingEngine.java
@@ -98,12 +98,12 @@ public class SparkProcessingEngine implements ProcessingEngine {
         roleMap.putAll(roles);
 
         try {
-            // Try as expression first.
+            // Try with expressions first.
             var expressionsList = expressionStrings.entrySet().stream().map(expressionEntry -> String.format(
                     "%s as %s", expressionEntry.getValue(), expressionEntry.getKey()
             )).collect(Collectors.toList());
             Dataset<Row> result = ds.selectExpr(Stream.concat(
-                    // Get the back the old columns.
+                    // Get back the old columns.
                     newNames.stream().filter(name -> !expressionStrings.containsKey(name)),
                     expressionsList.stream()
             ).toArray(String[]::new));

--- a/vtl-spark/src/test/java/fr/insee/vtl/spark/SparkDatasetTest.java
+++ b/vtl-spark/src/test/java/fr/insee/vtl/spark/SparkDatasetTest.java
@@ -1,6 +1,7 @@
 package fr.insee.vtl.spark;
 
 import fr.insee.vtl.model.InMemoryDataset;
+import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -25,6 +26,25 @@ public class SparkDatasetTest {
                 .appName("test")
                 .master("local")
                 .getOrCreate();
+    }
+
+    @Test
+    public void testFilters() {
+        StructType schema = DataTypes.createStructType(List.of(
+                DataTypes.createStructField("string", DataTypes.StringType, false),
+                DataTypes.createStructField("integer", DataTypes.LongType, false),
+                DataTypes.createStructField("boolean", DataTypes.BooleanType, false),
+                DataTypes.createStructField("float", DataTypes.DoubleType, false)
+        ));
+
+        Dataset<Row> dataFrame = spark.createDataFrame(List.of(
+                RowFactory.create("string", 1L, true, 1.5D)
+        ), schema);
+
+        dataFrame.filter("integer > 0").collectAsList();
+        dataFrame.filter((FilterFunction<Row>) row -> false).collectAsList();
+        dataFrame.selectExpr("integer + 2 as newInteger").collectAsList();
+
     }
 
     @Test


### PR DESCRIPTION
We try to interpret the vtl filter and calc expressions as-is since they are quite close to SQL expressions and most of them should be supported. We do that with best effort and fallback to function based implementation.