### PR TITLE
Adding an UnimplementedException

### DIFF
--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/exceptions/UnimplementedException.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/exceptions/UnimplementedException.java
@@ -1,0 +1,10 @@
+package fr.insee.vtl.engine.exceptions;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+
+public class UnimplementedException extends VtlScriptException {
+
+    public UnimplementedException(String msg, ParseTree tree) {
+        super(msg, tree);
+    }
+}

--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/ExpressionVisitor.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/ExpressionVisitor.java
@@ -304,10 +304,11 @@ public class ExpressionVisitor extends VtlBaseVisitor<ResolvableExpression> {
 
     @Override
     public  ResolvableExpression visitFunctionsExpression(VtlParser.FunctionsExpressionContext ctx) {
-        String text = ctx.getText();
         ResolvableExpression expr = super.visitFunctionsExpression(ctx);
         if (Objects.isNull(expr)) {
-            throw new  VtlRuntimeException(new UnimplementedException("This function is not yet implemented.", ctx));
+            VtlParser.FunctionsContext functionsContext = ctx.functions();
+            String functionName = functionsContext.getStart().getText();
+            throw new  VtlRuntimeException(new UnimplementedException("the function " + functionName + " is not yet implemented", ctx));
         }
         return expr;
     }

--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/ExpressionVisitor.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/ExpressionVisitor.java
@@ -1,5 +1,8 @@
 package fr.insee.vtl.engine.visitors.expression;
 
+import fr.insee.vtl.engine.exceptions.UnimplementedException;
+import fr.insee.vtl.engine.exceptions.VtlRuntimeException;
+import fr.insee.vtl.engine.exceptions.VtlScriptException;
 import fr.insee.vtl.engine.visitors.ClauseVisitor;
 import fr.insee.vtl.engine.visitors.expression.functions.*;
 import fr.insee.vtl.model.DatasetExpression;
@@ -297,5 +300,15 @@ public class ExpressionVisitor extends VtlBaseVisitor<ResolvableExpression> {
         DatasetExpression datasetExpression = (DatasetExpression) visit(ctx.dataset);
         ClauseVisitor clauseVisitor = new ClauseVisitor(datasetExpression, processingEngine);
         return clauseVisitor.visit(ctx.clause);
+    }
+
+    @Override
+    public  ResolvableExpression visitFunctionsExpression(VtlParser.FunctionsExpressionContext ctx) {
+        String text = ctx.getText();
+        ResolvableExpression expr = super.visitFunctionsExpression(ctx);
+        if (Objects.isNull(expr)) {
+            throw new  VtlRuntimeException(new UnimplementedException("This function is not yet implemented.", ctx));
+        }
+        return expr;
     }
 }

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/exceptions/UnimplementedExceptionTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/exceptions/UnimplementedExceptionTest.java
@@ -1,0 +1,34 @@
+package fr.insee.vtl.engine.exceptions;
+
+import fr.insee.vtl.model.Dataset;
+import fr.insee.vtl.model.InMemoryDataset;
+import fr.insee.vtl.model.Structured;
+import org.junit.jupiter.api.Test;
+
+import javax.script.*;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class UnimplementedExceptionTest {
+
+    @Test
+    public void testSimple() {
+        String vtlExpression = "a := first_value(ds over());";
+        Dataset ds = new InMemoryDataset(
+                List.of(List.of(1L, 31L)),
+                List.of(new Structured.Component("ID", Long.class, Dataset.Role.IDENTIFIER),
+                        new Structured.Component("FOO", Long.class, Dataset.Role.MEASURE))
+        );
+        SimpleBindings bindings = new SimpleBindings();
+        bindings.put("ds", ds);
+
+        ScriptEngine engine = new ScriptEngineManager().getEngineByName("vtl");
+        engine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
+
+        assertThatThrownBy(() -> {
+            engine.eval(vtlExpression);
+        }).isInstanceOf(UnimplementedException.class);
+    }
+}


### PR DESCRIPTION
The ExpressionVisitor will now throw an UnimplementedException when a function used in the VTL code is not implemented.