### PR TITLE
Fix/join

### DIFF
--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsVisitor.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsVisitor.java
@@ -57,25 +57,6 @@ public class JoinFunctionsVisitor extends VtlBaseVisitor<DatasetExpression> {
         }
     }
 
-    public static Optional<List<Component>> checkAtLeastOneCommonIdentifier(Collection<DatasetExpression> datasetExpressions) {
-        Set<Set<Component>> identifiers = new LinkedHashSet<>();
-        for (DatasetExpression datasetExpression : datasetExpressions) {
-            var structure = datasetExpression.getDataStructure();
-            var ids = new LinkedHashSet<Component>();
-            for (Component component : structure.values()) {
-                if (component.getRole().equals(Role.IDENTIFIER)) {
-                    ids.add(component);
-                }
-            }
-            identifiers.add(ids);
-        }
-        if (identifiers.size() != 1) {
-            return Optional.empty();
-        } else {
-            return Optional.of(new ArrayList<>(identifiers.iterator().next()));
-        }
-    }
-
     @Override
     public DatasetExpression visitJoinExpr(VtlParser.JoinExprContext ctx) {
         if (ctx.LEFT_JOIN() != null) {

--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsVisitor.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsVisitor.java
@@ -208,10 +208,16 @@ public class JoinFunctionsVisitor extends VtlBaseVisitor<DatasetExpression> {
                                 new InvalidArgumentException("using component " + name + " is not present in all datasets", fromContext(usingContext))
                         );
                     }
+                    if (!datasetExpression.getDataStructure().get(name).isIdentifier()) {
+                        throw new VtlRuntimeException(
+                                new InvalidArgumentException("using component " + name + " has to be an identifier", fromContext(usingContext))
+                        );
+                    }
                 }
                 Component component = datasets.values().iterator().next()
                         .getDataStructure().values().stream()
-                        .filter(c -> c.getName().equals(name)).collect(Collectors.toList()).get(0);
+                        .filter(c -> c.getName().equals(name))
+                        .collect(Collectors.toList()).get(0);
                 commonIdentifiers.add(component);
             }
         }
@@ -273,10 +279,16 @@ public class JoinFunctionsVisitor extends VtlBaseVisitor<DatasetExpression> {
                                 new InvalidArgumentException("using component " + name + " is not present in all datasets", fromContext(usingContext))
                         );
                     }
+                    if (!datasetExpression.getDataStructure().get(name).isIdentifier()) {
+                        throw new VtlRuntimeException(
+                                new InvalidArgumentException("using component " + name + " has to be an identifier", fromContext(usingContext))
+                        );
+                    }
                 }
                 Component component = datasets.values().iterator().next()
                         .getDataStructure().values().stream()
-                        .filter(c -> c.getName().equals(name)).collect(Collectors.toList()).get(0);
+                        .filter(c -> c.getName().equals(name))
+                        .collect(Collectors.toList()).get(0);
                 commonIdentifiers.add(component);
             }
         }

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
@@ -251,10 +251,10 @@ public class JoinFunctionsTest {
                 Arrays.asList("b", 2L, 4L, 10L)
         );
 
-//        assertThatThrownBy(() -> engine.eval("ds_3 := ds_2[rename m2 to m1];" +
-//                "result := inner_join(ds_1, ds_3);"))
-//                .isInstanceOf(InvalidArgumentException.class)
-//                .hasMessage("It is not allowed that two or more Components in the virtual Data Set have the same name");
+        assertThatThrownBy(() -> engine.eval("ds_3 := ds_2[rename m2 to m1];" +
+                "result := inner_join(ds_1, ds_3);"))
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessage("It is not allowed that two or more Components in the virtual Data Set have the same name");
 
         engine.eval("result := inner_join(ds_1 as ds1, ds_2 as ds2 using id1);");
 

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
@@ -132,7 +132,7 @@ public class JoinFunctionsTest {
         context.getBindings(ScriptContext.ENGINE_SCOPE).put("ds_1", dataset1);
         context.getBindings(ScriptContext.ENGINE_SCOPE).put("ds_2", dataset2);
 
-        engine.eval("result := left_join(ds_1, ds_2);");
+        engine.eval("result := left_join(ds_1, ds_2 using Id_2);");
         assertThat(((Dataset) engine.getContext().getAttribute("result")).getDataAsMap()).containsExactlyInAnyOrder(
                 Map.of("Id_1", 1L, "Id_2", 1L, "Me_1", "X"),
                 Map.of("Id_1", 1L, "Id_2", 2L, "Me_1", "Y"),
@@ -243,10 +243,10 @@ public class JoinFunctionsTest {
                 Arrays.asList("b", 2L, 4L, 10L)
         );
 
-        assertThatThrownBy(() -> engine.eval("ds_3 := ds_2[rename m2 to m1];" +
-                "result := inner_join(ds_1, ds_3);"))
-                .isInstanceOf(InvalidArgumentException.class)
-                .hasMessage("It is not allowed that two or more Components in the virtual Data Set have the same name");
+//        assertThatThrownBy(() -> engine.eval("ds_3 := ds_2[rename m2 to m1];" +
+//                "result := inner_join(ds_1, ds_3);"))
+//                .isInstanceOf(InvalidArgumentException.class)
+//                .hasMessage("It is not allowed that two or more Components in the virtual Data Set have the same name");
 
         engine.eval("result := inner_join(ds_1 as ds1, ds_2 as ds2 using id1);");
 

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
@@ -142,6 +142,11 @@ public class JoinFunctionsTest {
         assertThat(result.getDataStructure().get("Id_1").getRole().equals(Role.IDENTIFIER));
         assertThat(result.getDataStructure().get("Id_2").getRole().equals(Role.IDENTIFIER));
         assertThat(result.getDataStructure().get("Me_1").getRole().equals(Role.MEASURE));
+
+        assertThatThrownBy(() -> engine.eval("ds_1 := ds_1[calc measure Id_2 := Id_2];\n" +
+                "result := left_join(ds_1, ds_2 using Id_2);"))
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessage("using component Id_2 has to be an identifier");
     }
 
     @Test

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
@@ -133,12 +133,15 @@ public class JoinFunctionsTest {
         context.getBindings(ScriptContext.ENGINE_SCOPE).put("ds_2", dataset2);
 
         engine.eval("result := left_join(ds_1, ds_2 using Id_2);");
-        assertThat(((Dataset) engine.getContext().getAttribute("result")).getDataAsMap()).containsExactlyInAnyOrder(
+        Dataset result = ((Dataset) engine.getContext().getAttribute("result"));
+        assertThat(result.getDataAsMap()).containsExactlyInAnyOrder(
                 Map.of("Id_1", 1L, "Id_2", 1L, "Me_1", "X"),
                 Map.of("Id_1", 1L, "Id_2", 2L, "Me_1", "Y"),
                 Map.of("Id_1", 2L, "Id_2", 1L, "Me_1", "X")
         );
-
+        assertThat(result.getDataStructure().get("Id_1").getRole().equals(Role.IDENTIFIER));
+        assertThat(result.getDataStructure().get("Id_2").getRole().equals(Role.IDENTIFIER));
+        assertThat(result.getDataStructure().get("Me_1").getRole().equals(Role.MEASURE));
     }
 
     @Test

--- a/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
+++ b/vtl-engine/src/test/java/fr/insee/vtl/engine/visitors/expression/functions/JoinFunctionsTest.java
@@ -105,6 +105,43 @@ public class JoinFunctionsTest {
     }
 
     @Test
+    public void testLeftJoinWithDifferentIdentifiers() throws ScriptException {
+        InMemoryDataset dataset1 = new InMemoryDataset(
+                List.of(
+                        List.of(1L, 1L),
+                        List.of(1L, 2L),
+                        List.of(2L, 1L)
+                ),
+                List.of(
+                        new Structured.Component("Id_1", Long.class, Role.IDENTIFIER),
+                        new Structured.Component("Id_2", Long.class, Role.IDENTIFIER)
+                )
+        );
+        InMemoryDataset dataset2 = new InMemoryDataset(
+                List.of(
+                        List.of(1L, "X"),
+                        List.of(2L, "Y")
+                ),
+                List.of(
+                        new Structured.Component("Id_2", Long.class, Role.IDENTIFIER),
+                        new Structured.Component("Me_1", String.class, Role.MEASURE)
+                )
+        );
+
+        ScriptContext context = engine.getContext();
+        context.getBindings(ScriptContext.ENGINE_SCOPE).put("ds_1", dataset1);
+        context.getBindings(ScriptContext.ENGINE_SCOPE).put("ds_2", dataset2);
+
+        engine.eval("result := left_join(ds_1, ds_2);");
+        assertThat(((Dataset) engine.getContext().getAttribute("result")).getDataAsMap()).containsExactlyInAnyOrder(
+                Map.of("Id_1", 1L, "Id_2", 1L, "Me_1", "X"),
+                Map.of("Id_1", 1L, "Id_2", 2L, "Me_1", "Y"),
+                Map.of("Id_1", 2L, "Id_2", 1L, "Me_1", "X")
+        );
+
+    }
+
+    @Test
     public void testLeftJoinWithDouble() throws ScriptException {
         InMemoryDataset dataset1 = new InMemoryDataset(
                 List.of(


### PR DESCRIPTION
 Fix #256 
If using is filled, we check is listed ids are presents in each dataset and their role is identifier.
If using is not provided, we check if all datasets have same identifiers.
