### PR TITLE
Harmonize antlr version because of spark

### DIFF
--- a/vtl-parser/pom.xml
+++ b/vtl-parser/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.8</version>
+            <version>4.7.2</version>
         </dependency>
     </dependencies>
 
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.8</version>
+                <version>4.7.2</version>
                 <executions>
                     <execution>
                         <configuration>


### PR DESCRIPTION
With 4.8, parsing failed for hierarchical ruleset definition (spark provides antlr 4.7.2)