### PR TITLE
Remove Automatic module name

### DIFF
--- a/vtl-spark/pom.xml
+++ b/vtl-spark/pom.xml
@@ -63,13 +63,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>fr.insee.vtl.spark</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Remove automatic module name from manifest, as trevas-spark is resulting per default in a valid module name
- Javadoc plugin is fetching every module name of the dependencies when it is set
  -  Currently fails for spark dependencies
  - See also [https://issues.apache.org/jira/browse/SPARK-23543]( https://issues.apache.org/jira/browse/SPARK-23543)