### PR TITLE
Expose registered methods on VtlScriptEngine

### DIFF
--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/VtlScriptEngine.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/VtlScriptEngine.java
@@ -399,4 +399,14 @@ public class VtlScriptEngine extends AbstractScriptEngine {
     }
     return globalRegistry.putAndReturnPrevious(name, method);
   }
+
+  /** Read-only view of the natively registered functions, keyed by VTL function name. */
+  public Map<String, List<Method>> getRegisteredMethods() {
+    return functionRegistry.asMap();
+  }
+
+  /** Read-only view of the globally registered functions, keyed by VTL function name. */
+  public Map<String, List<Method>> getRegisteredGlobalMethods() {
+    return globalRegistry == null ? Map.of() : globalRegistry.asMap();
+  }
 }

--- a/vtl-engine/src/main/java/fr/insee/vtl/engine/functions/NativeFunctionRegistry.java
+++ b/vtl-engine/src/main/java/fr/insee/vtl/engine/functions/NativeFunctionRegistry.java
@@ -8,6 +8,7 @@ import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,6 +53,14 @@ public final class NativeFunctionRegistry {
 
   public static NativeFunctionRegistry empty() {
     return new NativeFunctionRegistry();
+  }
+
+  /**
+   * Unmodifiable live view of the registered bindings, keyed by VTL function name. Reflects
+   * subsequent registrations; each value is the (immutable) list of overloads for that name.
+   */
+  public Map<String, List<Method>> asMap() {
+    return Collections.unmodifiableMap(byVtlName);
   }
 
   public void registerAll(Map<String, List<Method>> functions) {


### PR DESCRIPTION
Adds two read-only accessors to `VtlScriptEngine`:

- `getRegisteredMethods()`
- `getRegisteredGlobalMethods()`

They return unmodifiable views of the already-cached method maps, allowing external tooling to introspect the functions registered on the engine (e.g. for completion and diagnostics) without exposing the internal caches.

No behavioural change to the engine itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)